### PR TITLE
Consolidate several run lines to shrink generated image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,17 @@ MAINTAINER bistromath@gmail.com version: 0.5
 
 WORKDIR /opt
 
-RUN apt-get update && apt-get dist-upgrade -yf && apt-get clean && apt-get autoremove
-RUN apt-get install -y git wget zip unzip \
+RUN apt-get update && apt-get dist-upgrade -yf && apt-get clean && apt-get autoremove && apt-get install -y git wget zip unzip \
  cmake build-essential git-core cmake g++ python-dev swig pkg-config \
  libboost-all-dev python-lxml python-sip-dev python-requests \
- libzmq3-dev python-mako python-pysnmp4 libusb-1.0-0 libusb-1.0-0-dev
+ libzmq3-dev python-mako python-pysnmp4 libusb-1.0-0 libusb-1.0-0-dev && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/EttusResearch/uhd.git
+RUN git clone https://github.com/EttusResearch/uhd.git && cd uhd && git checkout ${uhd_tag} && rm -rf .git
 WORKDIR /opt/uhd/host
-RUN git checkout ${uhd_tag}
 
 RUN mkdir build \
  && cd build \
  && cmake ../ -DENABLE_B100=1 -DENABLE_B200=1 -DENABLE_E100=0 -DENABLE_E300=0 -DENABLE_EXAMPLES=1 -DENABLE_DOXYGEN=0 -DENABLE_MANUAL=0 -DENABLE_MAN_PAGES=0 -DENABLE_OCTOCLOCK=0 -DENABLE_ORC=0 -DENABLE_USRP1=0 -DENABLE_USRP2=1 -DENABLE_UTILS=1 -DENABLE_X300=1 \
  && make -j${threads} \
  && make install \
- && ldconfig
+ && ldconfig && cd .. && rm -rf build


### PR DESCRIPTION
I'm still new at this, but it looks like several intermediate fs layers were being created here that make the final image size larger than it needs to be.
```
Before:
Tag Name	Compressed Size	Last Updated
3.10.2		514 MB		2 days ago
After:
Tag Name	Compressed Size	Last Updated
latest		348 MB		5 minutes ago
```
I haven't verified that all the functionality of uhd still works, because I don't have a USRP myself, but gnuradio successfully builds when inheriting from this instead of the existing public image.

The image is up at https://hub.docker.com/r/r4v5/uhd/tags/ and a corresponding image doing similar things with docker-gnuradio is available at https://hub.docker.com/r/r4v5/gnuradio/tags/ (which I can also PR if you're interested). As you can see, it sheds about 300MB from the final gnuradio image by cleaning up artifacts.